### PR TITLE
Correct metadata dependencies

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,6 @@ galaxy_info:
   min_ansible_version: 1.7
   categories:
     - cloud
-  dependencies: []
   platforms:
     - name: Ubuntu
       versions:
@@ -20,3 +19,4 @@ galaxy_info:
       versions:
         - 6
         - 7
+dependencies: []


### PR DESCRIPTION
Role fails to install via ansible-galaxy due to incorrect nesting
of the `dependencies` key
- openstack-ansible-galaxy.openstack-glance was installed successfully
  Traceback (most recent call last):
  File "/usr/local/Cellar/ansible/1.9.2/libexec/bin/ansible-galaxy", line 959, in <module>
    main()
  File "/usr/local/Cellar/ansible/1.9.2/libexec/bin/ansible-galaxy", line 953, in main
    fn(args, options, parser)
  File "/usr/local/Cellar/ansible/1.9.2/libexec/bin/ansible-galaxy", line 845, in execute_install
    role_dependencies = role_data['dependencies']
  KeyError: 'dependencies'
