### PR TITLE
Enable services

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,8 +27,8 @@
 - meta: flush_handlers
 
 - name: Make sure Glance registry is started
-  service: name={{ glance_registry_service }} state=started
+  service: name={{ glance_registry_service }} state=started enabled=yes
 - name: Make sure Glance API is started
-  service: name={{ glance_api_service }} state=started
+  service: name={{ glance_api_service }} state=started enabled=yes
 - name: Wait Glance
   wait_for: host="{{ glance_hostname }}" port="{{ glance_port }}"


### PR DESCRIPTION
Real minor change, but the service should also be enabled to that
subsequent boots can start it without needing the role to start it
explicitly.
