### PR TITLE
Only run db sync on bootstrap node

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,3 +44,6 @@ glance_rabbit_host: localhost
 glance_rabbit_port: 5672
 glance_rabbit_hosts: "{{ glance_rabbit_host }}:{{ glance_rabbit_port }}"
 glance_rabbit_ha_queues: False
+
+# Misc
+glance_boostrap: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -43,3 +43,4 @@
   notify:
     - Restart Glance API
     - Restart Glance registry
+  when: glance_boostrap


### PR DESCRIPTION
We run into contention when multiple systems converge and run
simultaneous db syncs.
