### PR TITLE
Vagrant with Xenial and VirtualBox Provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.log
 *.retry
 .vagrant/
+tests/inventory

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -1,56 +1,52 @@
 # -*- mode: ruby -*-
-
-PROVIDER = "libvirt"
-INVENTORY_PATH = 'inventory'
+# vi: set ft=ruby :
 
 ######################################################################
 
-def inventory_line(ip, name, provider="libvirt")
-     "#{name} ansible_ssh_host=#{ip} ansible_ssh_private_key_file=.vagrant/machines/#{name}/#{provider}/private_key\n"
-end
-
-def start(config, box, name, ip, netmask = "255.255.255.0")
+def start(config, box, name, extra_provisioners=[])
   config.vm.define name do |node|
     node.vm.box = box
     node.vm.hostname = name
-    node.vm.network :private_network, :ip => ip, :netmask => netmask
+
+    if not extra_provisioners.empty? then
+      for extra_provisioner in extra_provisioners do
+        extra_provisioner.call(node)
+      end
+    end
+
+    node.vm.provision :ansible do |ansible|
+      ansible.playbook = "test.yml"
+    end
   end
-
-  config.vm.provision :shell,
-                      inline: "test -d /root/.ssh || cp -r /home/vagrant/.ssh /root"
-  config.vm.provision :shell,
-                      inline: "sudo sed -i 's/ALL=NOPASSWD:ALL/ALL=(ALL:ALL) NOPASSWD: ALL/g' /etc/sudoers"
-
-
-  File.open(INVENTORY_PATH, 'a') do |fd|
-    fd << inventory_line(ip, name, provier=PROVIDER)
-  end
-
 end
 
 def set_hardware(config, provider)
   config.vm.provider provider do |machine|
-    machine.memory = 1024
+    machine.memory = 2048
     machine.cpus = 1
   end
 end
 
+def install_python_ubuntu(node)
+  node.vm.provision :shell,
+    inline: "apt-get update && apt-get install -y python"
+end
 
 ######################################################################
-
-
-File.open(INVENTORY_PATH, 'w') do |fd|
-end
 
 Vagrant.configure(2) do |config|
   set_hardware config, :libvirt
   set_hardware config, :virtualbox
 
-  start config, "baremettle/ubuntu-14.04", "ubuntu", "192.168.1.100"
-  start config, "centos/7",                "centos", "192.168.1.101"
-
-  config.vm.provision :ansible do |ansible|
-    ansible.playbook = "test.yml"
+  config.vm.provider :libvirt do |libvirt|
+    start config, "iknite/trusty64",   "ubuntu-trusty"
+    start config, "yk0/ubuntu-xenial", "ubuntu-xenial", [method(:install_python_ubuntu)]
+    start config, "centos/7",          "centos-7"
   end
 
+  config.vm.provider :virtualbox do |libvirt|
+    start config, "ubuntu/trusty64", "ubuntu-trusty"
+    start config, "ubuntu/xenial64", "ubuntu-xenial", [method(:install_python_ubuntu)]
+    start config, "centos/7",        "centos-7"
+  end
 end

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -2,4 +2,4 @@
 allow_world_readable_tmpfiles = True
 host_key_checking = False
 log_path = ./ansible.log
-roles_path = ../../
+roles_path = roles:../../

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,2 +1,0 @@
-ubuntu ansible_ssh_host=192.168.1.100 ansible_ssh_private_key_file=.vagrant/machines/ubuntu/libvirt/private_key
-centos ansible_ssh_host=192.168.1.101 ansible_ssh_private_key_file=.vagrant/machines/centos/libvirt/private_key

--- a/tests/inventory_local
+++ b/tests/inventory_local
@@ -1,1 +1,0 @@
-localhost

--- a/tests/roles/.gitignore
+++ b/tests/roles/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Add Ubuntu Xenial as a Vagrant test environment.  To achieve this,
changing Vagrant provider to VirtualBox (since there are no good box for
Xenial).  Also, change box for Trusty to `ubuntu/trusty64` since it is
the official box and there are no obstacle to use it anymore.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
