### PR TITLE
Fix Vagrant with Libvirt

### DIFF
--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -3,9 +3,16 @@
 
 ######################################################################
 
-def start(config, box, name, extra_provisioners=[])
+def start(config, name, box_libvirt, box_virtualbox, extra_provisioners=[])
   config.vm.define name do |node|
-    node.vm.box = box
+    node.vm.provider :libvirt do |libvirt, libvirt_node|
+      libvirt_node.vm.box = box_libvirt
+    end
+
+    node.vm.provider :virtualbox do |virtualbox, virtualbox_node|
+      virtualbox_node.vm.box = box_virtualbox
+    end
+
     node.vm.hostname = name
 
     if not extra_provisioners.empty? then
@@ -27,6 +34,11 @@ def set_hardware(config, provider)
   end
 end
 
+def fix_sudoers(node)
+  node.vm.provision :shell,
+    inline: "echo 'vagrant ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/vagrant"
+end
+
 def install_python_ubuntu(node)
   node.vm.provision :shell,
     inline: "apt-get update && apt-get install -y python"
@@ -38,15 +50,17 @@ Vagrant.configure(2) do |config|
   set_hardware config, :libvirt
   set_hardware config, :virtualbox
 
-  config.vm.provider :libvirt do |libvirt|
-    start config, "iknite/trusty64",   "ubuntu-trusty"
-    start config, "yk0/ubuntu-xenial", "ubuntu-xenial", [method(:install_python_ubuntu)]
-    start config, "centos/7",          "centos-7"
-  end
+  start config,
+        "ubuntu-trusty",
+        "sputnik13/trusty64",
+        "ubuntu/trusty64",
+        [method(:fix_sudoers)]
 
-  config.vm.provider :virtualbox do |libvirt|
-    start config, "ubuntu/trusty64", "ubuntu-trusty"
-    start config, "ubuntu/xenial64", "ubuntu-xenial", [method(:install_python_ubuntu)]
-    start config, "centos/7",        "centos-7"
-  end
+  start config,
+        "ubuntu-xenial",
+        "yk0/ubuntu-xenial",
+        "ubuntu/xenial64",
+        [method(:install_python_ubuntu)]
+
+  start config, "centos-7", "centos/7", "centos/7"
 end

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -9,4 +9,4 @@
 - src: 'https://github.com/openstack-ansible-galaxy/rabbitmq.git'
 
 - src: 'https://github.com/openstack-ansible-galaxy/openstack-keystone'
-  version: 'features/mitaka'
+  version: 'origin/features/mitaka'


### PR DESCRIPTION
Since most of the box does not work with libvirt, we need to specify
different boxes for different providers.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
