### PR TITLE
Disable Truthy Checks

### DIFF
--- a/.yamllint.conf
+++ b/.yamllint.conf
@@ -5,3 +5,4 @@ extends: default
 rules:
   line-length:
     max: 160
+  truthy: disable

--- a/tests/test_common.yml
+++ b/tests/test_common.yml
@@ -7,6 +7,7 @@
     - name: Update local apt cache (Ubuntu)
       apt:
         update_cache: True
+      changed_when: False
       when: ansible_os_family == 'Debian'
 
     - name: Install policycoreutils-python


### PR DESCRIPTION
YAMLLint have introduced truthy checks in the following commit
(https://github.com/adrienverge/yamllint/commit/1f472bc)
, however we are not going to stick to this rule for now, since we
already uniformed our booleans to `True` or `False`.

Signed-off-by: Ryo Tagami <rtagami@airstrip.jp>